### PR TITLE
change empty cookie string to have double quotes

### DIFF
--- a/lib/src/plugin.dart
+++ b/lib/src/plugin.dart
@@ -369,7 +369,7 @@ class AngelAuth<User> {
 
       if (allowCookie == true) {
         res.cookies.removeWhere((cookie) => cookie.name == "token");
-        _addProtectedCookie(res, 'token', '');
+        _addProtectedCookie(res, 'token', '""');
       }
 
       if (options != null &&


### PR DESCRIPTION
Setting a cookie with an empty string `''` causes a crash.

See: https://github.com/dart-lang/sdk/issues/35189

This will fix the logout which now causes a 500 crash